### PR TITLE
Use setuptools.find_packages to include all python packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 needs_pytest = {"pytest", "test", "ptr"}.intersection(sys.argv)
 pytest_runner = ["pytest-runner==4.2"] if needs_pytest else []
@@ -21,9 +21,8 @@ tests_require = [
 ]
 setup(
     name="good_smell",
-    version="0.6",
-    py_modules=["good_smell"],
-    packages=["good_smell"],
+    version="0.6.1",
+    packages=[find_packages(exclude=("tests",))],
     setup_requires=[] + pytest_runner,
     install_requires=[
         "fire==0.1.3",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ tests_require = [
 setup(
     name="good_smell",
     version="0.6.1",
-    packages=[find_packages(exclude=("tests",))],
+    packages=find_packages(exclude=("tests",)),
     setup_requires=[] + pytest_runner,
     install_requires=[
         "fire==0.1.3",
@@ -35,7 +35,6 @@ setup(
     author_email="tomer.keren.dev@gmail.com",
     description="A linter/refactoring tool to make your code smell better!",
     long_description=long_description,
-    long_description_content_type="text/markdown",
     license="BSD",
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Always use find_packages...
py_modules is for listing individual files and so is not necessary
Closes #34