### PR TITLE
Add smell: Warn when `str.join`ing a constant amount of members and prefer to str.format.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,12 @@
 exclude: 'examples/.*\.py'
 repos:
--   repo: https://github.com/ambv/black
-    rev: stable
-    hooks:
-    - id: black
+- repo: https://github.com/ambv/black
+  rev: stable
+  hooks:
+  - id: black
+- repo: https://github.com/pycqa/isort
+  rev: 5.6.3
+  hooks:
+    - id: isort
+      name: isort (python)
+      args: ["--profile", "black"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 exclude: 'examples/.*\.py'
 repos:
 - repo: https://github.com/ambv/black
-  rev: stable
+  rev: 20.8b1
   hooks:
   - id: black
 - repo: https://github.com/pycqa/isort
-  rev: 5.6.3
+  rev: 5.8.0
   hooks:
     - id: isort
       name: isort (python)

--- a/docs/generate_smell_doc.py
+++ b/docs/generate_smell_doc.py
@@ -8,8 +8,7 @@ def generate_smell_docs():
         print(
             f"""### {desc} ({symbol})
 ```py
-{before}
-```
+{before}```
 Will be fixed to
 ```py
 {after}```"""

--- a/docs/smell_list.md
+++ b/docs/smell_list.md
@@ -1,3 +1,16 @@
+### Warn when using join on a (short) list of known literals. (join-literal)
+```py
+a = "foo"
+b = "bar"
+",".join([a, b])
+
+```
+Will be fixed to
+```py
+a = "foo"
+b = "bar"
+"{},{}".format(a, b)
+```
 ### Use "yield from" instead of yield inside of a for loop (yield-from)
 ```py
 seq = range(10)

--- a/docs/smell_list.md
+++ b/docs/smell_list.md
@@ -3,7 +3,6 @@
 a = "foo"
 b = "bar"
 ",".join([a, b])
-
 ```
 Will be fixed to
 ```py
@@ -16,7 +15,6 @@ b = "bar"
 seq = range(10)
 for x in seq:
     yield x
-
 ```
 Will be fixed to
 ```py
@@ -28,7 +26,6 @@ yield from seq
 for i in range(len(sequence)):
     a = sequence[i]
     print(a)
-
 ```
 Will be fixed to
 ```py
@@ -41,7 +38,6 @@ for i in range(10):
     if i == 2:
         print(1)
         print(2)
-
 ```
 Will be fixed to
 ```py
@@ -56,7 +52,6 @@ seq_b = range(10)
 for i in seq_a:
     for j in seq_b:
         print(i, j)
-
 ```
 Will be fixed to
 ```py

--- a/docs/smell_list.md
+++ b/docs/smell_list.md
@@ -1,4 +1,4 @@
-### Warn when using join on a (short) list of known literals. (join-literal)
+### Warn when using join on a list of known literals. (join-literal)
 ```py
 a = "foo"
 b = "bar"

--- a/good_smell/main.py
+++ b/good_smell/main.py
@@ -1,9 +1,9 @@
 from pathlib import Path
+from typing import Iterable, Type
 
 from fire import Fire
-from typing import Type, Iterable
 
-from good_smell import LintSmell, implemented_smells, SmellWarning
+from good_smell import LintSmell, SmellWarning, implemented_smells
 
 
 def print_smell_warnings(path: str):
@@ -19,7 +19,7 @@ def print_smell_warnings(path: str):
 def smell_warnings(source: str, path: str = "") -> Iterable[SmellWarning]:
     for smell in implemented_smells:
         yield from smell.from_source(
-            source_code=source, path=str(path)
+            source_code=source, path=str(path), transform=False
         ).check_for_smell()
 
 
@@ -37,7 +37,11 @@ def fix_smell(
     smell: Type[LintSmell]
     for smell in implemented_smells:
         source = smell.from_source(
-            source, starting_line, end_line, path=path
+            source_code=source,
+            start_line=starting_line,
+            end_line=end_line,
+            path=path,
+            transform=True,
         ).fix_smell()
     return source
 

--- a/good_smell/smells/__init__.py
+++ b/good_smell/smells/__init__.py
@@ -1,6 +1,7 @@
-from .range_len_fix import RangeLenSmell
-from .nested_for import NestedFor
 from .filter import FilterIterator
+from .join_literal import JoinLiteral
+from .nested_for import NestedFor
+from .range_len_fix import RangeLenSmell
 from .yield_from import YieldFrom
 
-implemented_smells = (RangeLenSmell, NestedFor, FilterIterator, YieldFrom)
+implemented_smells = (RangeLenSmell, NestedFor, FilterIterator, YieldFrom, JoinLiteral)

--- a/good_smell/smells/join_literal.py
+++ b/good_smell/smells/join_literal.py
@@ -1,0 +1,38 @@
+import ast
+
+from good_smell import AstSmell, LoggingTransformer
+
+
+class JoinLiteral(AstSmell):
+    """Checks if joining a literal of a sequence."""
+
+    @property
+    def transformer_class(self):
+        return NestedForTransformer
+
+    @property
+    def warning_message(self):
+        return (
+            "Consider using str.format instead of joining a constant amount of strings."
+        )
+
+    @property
+    def symbol(self):
+        return "join-literal"
+
+
+class NestedForTransformer(LoggingTransformer):
+    """NodeTransformer that goes visits all the nested `for`s and replaces them
+    with itertools.product"""
+
+    @staticmethod
+    def is_smelly(node: ast.AST):
+        """Check if the node is only a nested for"""
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Constant)
+            and node.func.attr == "join"
+            and len(node.args) == 1
+            and isinstance(node.args[0], ast.List)
+        )

--- a/good_smell/smells/join_literal.py
+++ b/good_smell/smells/join_literal.py
@@ -66,4 +66,5 @@ class Transformer(LoggingTransformer):
             and node.func.attr == "join"
             and len(node.args) == 1
             and isinstance(node.args[0], ast.List)
+            and not any(isinstance(el, ast.Starred) for el in node.args[0].elts)
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ pre-commit = "*"
 pytest = "*"
 autopep8 = "*"
 pylint = "*"
-black = "==18.9b0"
+black = "==20.8b1"
 
 [tool.poetry.scripts]
 good_smell = "good_smell:main"

--- a/tests/examples/example.py
+++ b/tests/examples/example.py
@@ -7,7 +7,7 @@ after = 0
 after = 1
 # END
 #: example
-# example-symbol,another-one
+# None
 before = 0
 before = 1
 # ==>

--- a/tests/examples/join_literal.py
+++ b/tests/examples/join_literal.py
@@ -28,3 +28,9 @@ iterable = ["a","b"]
 # ==>
 ",".join([str(i) for i in range(100)])
 # END
+#: Don't warn when the list literal includes an unpacking
+# None
+",".join([1,2,3,*a])
+# ==>
+",".join([1,2,3,*a])
+# END

--- a/tests/examples/join_literal.py
+++ b/tests/examples/join_literal.py
@@ -1,0 +1,28 @@
+#: Warn when using join on a (short) list of known literals.
+# join_literal
+a = "foo"
+b = "bar"
+",".join([a, b])
+# ==>
+"{},{}".format(a, b)
+# END
+#: Don't warn when joining an iterable
+# None
+iterable = ["a","b"]
+",".join(iterable)
+# ==>
+iterable = ["a","b"]
+",".join(iterable)
+# END
+#: Don't warn when joining a generator expression
+# None
+",".join(str(i) for i in range(100))
+# ==>
+",".join(str(i) for i in range(100))
+# END
+#: Don't warn when joining a list comprehension
+# None
+",".join([str(i) for i in range(100)])
+# ==>
+",".join([str(i) for i in range(100)])
+# END

--- a/tests/examples/join_literal.py
+++ b/tests/examples/join_literal.py
@@ -1,4 +1,4 @@
-#: Warn when using join on a (short) list of known literals.
+#: Warn when using join on a list of known literals.
 # join-literal
 a = "foo"
 b = "bar"

--- a/tests/examples/join_literal.py
+++ b/tests/examples/join_literal.py
@@ -1,5 +1,5 @@
 #: Warn when using join on a (short) list of known literals.
-# join_literal
+# join-literal
 a = "foo"
 b = "bar"
 ",".join([a, b])

--- a/tests/examples/join_literal.py
+++ b/tests/examples/join_literal.py
@@ -4,6 +4,8 @@ a = "foo"
 b = "bar"
 ",".join([a, b])
 # ==>
+a = "foo"
+b = "bar"
 "{},{}".format(a, b)
 # END
 #: Don't warn when joining an iterable

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -7,6 +7,7 @@ from typing import Iterator, NamedTuple, Set
 import astor
 import black
 import pytest
+
 from good_smell import fix_smell, smell_warnings
 
 FILE_DIR = Path(__file__).parent

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,7 +1,9 @@
+import ast
 import itertools
 from os import PathLike
 from pathlib import Path
 from typing import Iterator, Set, NamedTuple
+import astor
 
 import black
 import pytest
@@ -14,6 +16,7 @@ EXAMPLES_DIR = FILE_DIR / "examples"
 
 def normalize_formatting(code: str) -> str:
     """Returns a string of the code with normalized formatting for easier compares"""
+    code = astor.to_source(ast.parse(code))
     try:
         return black.format_file_contents(code, line_length=88, fast=True)
     except black.NothingChanged:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -18,7 +18,7 @@ def normalize_formatting(code: str) -> str:
     """Returns a string of the code with normalized formatting for easier compares"""
     code = astor.to_source(ast.parse(code))
     try:
-        return black.format_file_contents(code, line_length=88, fast=True)
+        return black.format_file_contents(code, fast=True, mode=black.Mode())
     except black.NothingChanged:
         return code
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -86,7 +86,7 @@ def params_from_file():
                 case.before,
                 case.after,
                 case.error_symbols,
-                id=file.name + ":" + case.desc,
+                id=f"{file.with_suffix('').name}:{case.desc}",
             )
             for case in collect_tests(file)
         )


### PR DESCRIPTION
### Warn when using join on a list of known literals. (join-literal)
```py
a = "foo"
b = "bar"
",".join([a, b])
```
Will be fixed to
```py
a = "foo"
b = "bar"
"{},{}".format(a, b)
```

The fix ended up being static-evaluation of the str.join which is neat
Also snuk in some CI bookkeeping :)